### PR TITLE
fix memory leak in forever.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Memory leak in forever with Bluebird long stack traces enabled.
+
 ## [0.2.1] 2017-10-06
 
 ### Fixed
@@ -21,6 +27,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Replaced custom implementation of [JSON pointer](https://tools.ietf.org/html/rfc6901) with [json-pointer](https://www.npmjs.com/package/json-pointer).
 
+[Unreleased]: https://github.com/Merlin-Taylor/environment-manager/compare/0.2.1...HEAD
 [0.2.1]: https://github.com/Merlin-Taylor/environment-manager/compare/0.2.0...0.2.1
 [0.2.0]: https://github.com/Merlin-Taylor/environment-manager/compare/0.1.1...0.2.0
 [0.1.1]: https://github.com/Merlin-Taylor/environment-manager/compare/0.1.1-rc1...0.1.1

--- a/lib/forever.js
+++ b/lib/forever.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const Promise = require('bluebird');
 
 function foreverAsync(cancellationToken, fn, init) {
   assert(cancellationToken);
@@ -6,15 +7,23 @@ function foreverAsync(cancellationToken, fn, init) {
   const { cancel } = cancellationToken;
   assert(typeof cancel === 'boolean');
 
-  const resolveImmediate = () => new Promise(resolve => setImmediate(resolve));
-
-  function recur(result) {
-    return cancellationToken.cancel
-      ? Promise.resolve(result)
-      : resolveImmediate().then(() => result).then(fn).then(recur);
-  }
-
-  return recur(init);
+  const fnP = Promise.method(fn);
+  return new Promise((resolve, reject) => {
+    /*
+    * The previous implementation of recur was a simple recursive function returning a Promise.
+    * This resulted in a memory leak when combined with bluebird.longStackTraces, a feature which
+    * accumulates stack information from one chained promise to the next.
+    * The implementation below fixes this by using setImmediate to break the chain of Promises.
+    */
+    function recur(state) {
+      if (cancellationToken && cancellationToken.cancel) {
+        resolve(state);
+      } else {
+        setImmediate(() => fnP(state).then(recur, (e) => { reject(e); }));
+      }
+    }
+    recur(init);
+  });
 }
 
 module.exports = foreverAsync;


### PR DESCRIPTION
This change is a fix for #1. The previous implementation of recur was a simple recursive function returning a Promise. This resulted in a memory leak when combined with Bluebird long stack traces, a feature which accumulates stack information from one chained promise to the next. The implementation below fixes this by using `setImmediate` to break the chain of Promises.